### PR TITLE
Add interactive 9x9 Go board

### DIFF
--- a/src/board.js
+++ b/src/board.js
@@ -1,0 +1,110 @@
+class GoGame {
+  constructor(size = 9) {
+    this.size = size;
+    this.board = Array.from({ length: size }, () => Array(size).fill(0));
+    this.currentPlayer = 1; // 1 = black, 2 = white
+    this.history = [this.cloneBoard(this.board)];
+  }
+
+  cloneBoard(board) {
+    return board.map((row) => row.slice());
+  }
+
+  boardToString(board) {
+    return board.flat().join('');
+  }
+
+  isOnBoard(x, y) {
+    return x >= 0 && x < this.size && y >= 0 && y < this.size;
+  }
+
+  getAdjacent(x, y) {
+    return [
+      { x: x + 1, y },
+      { x: x - 1, y },
+      { x, y: y + 1 },
+      { x, y: y - 1 },
+    ].filter((p) => this.isOnBoard(p.x, p.y));
+  }
+
+  getGroup(x, y, board = this.board, visited = new Set()) {
+    const color = board[x][y];
+    if (color === 0) return [];
+    const key = (a, b) => `${a},${b}`;
+    const stack = [[x, y]];
+    visited.add(key(x, y));
+    const group = [];
+    while (stack.length) {
+      const [cx, cy] = stack.pop();
+      group.push([cx, cy]);
+      for (const p of this.getAdjacent(cx, cy)) {
+        if (board[p.x][p.y] === color && !visited.has(key(p.x, p.y))) {
+          visited.add(key(p.x, p.y));
+          stack.push([p.x, p.y]);
+        }
+      }
+    }
+    return group;
+  }
+
+  getLiberties(group, board = this.board) {
+    const seen = new Set();
+    let count = 0;
+    const key = (a, b) => `${a},${b}`;
+    for (const [x, y] of group) {
+      for (const p of this.getAdjacent(x, y)) {
+        if (board[p.x][p.y] === 0 && !seen.has(key(p.x, p.y))) {
+          seen.add(key(p.x, p.y));
+          count += 1;
+        }
+      }
+    }
+    return count;
+  }
+
+  attemptPlace(x, y) {
+    if (!this.isOnBoard(x, y) || this.board[x][y] !== 0) return false;
+    const color = this.currentPlayer;
+    const opp = color === 1 ? 2 : 1;
+
+    let newBoard = this.cloneBoard(this.board);
+    newBoard[x][y] = color;
+
+    // Capture opponent groups
+    for (const p of this.getAdjacent(x, y)) {
+      if (newBoard[p.x][p.y] === opp) {
+        const group = this.getGroup(p.x, p.y, newBoard);
+        if (this.getLiberties(group, newBoard) === 0) {
+          for (const [gx, gy] of group) newBoard[gx][gy] = 0;
+        }
+      }
+    }
+
+    // Suicide check
+    const group = this.getGroup(x, y, newBoard);
+    if (this.getLiberties(group, newBoard) === 0) {
+      return false;
+    }
+
+    // Ko check
+    if (this.history.length >= 2) {
+      const prevStr = this.boardToString(this.history[this.history.length - 2]);
+      if (prevStr === this.boardToString(newBoard)) return false;
+    }
+
+    this.board = newBoard;
+    this.history.push(this.cloneBoard(this.board));
+    this.currentPlayer = opp;
+    return true;
+  }
+
+  undo() {
+    if (this.history.length <= 1) return false;
+    this.history.pop();
+    this.board = this.cloneBoard(this.history[this.history.length - 1]);
+    this.currentPlayer = this.currentPlayer === 1 ? 2 : 1;
+    return true;
+  }
+}
+
+export default GoGame;

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,89 @@
-document.querySelector("#app").innerHTML = `
+import GoGame from './board.js';
+
+const app = document.querySelector('#app');
+app.innerHTML = `
   <h1>Kifu Compass</h1>
+  <canvas id="board" width="450" height="450"></canvas>
+  <div>
+    <button id="undo">Back</button>
+  </div>
+  <div id="suggestion"></div>
 `;
+
+const canvas = document.getElementById('board');
+const ctx = canvas.getContext('2d');
+const game = new GoGame(9);
+
+const CELL_SIZE = canvas.width / (game.size + 1);
+
+function drawBoard() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 1;
+  for (let i = 0; i < game.size; i++) {
+    ctx.beginPath();
+    ctx.moveTo(CELL_SIZE, CELL_SIZE * (i + 1));
+    ctx.lineTo(CELL_SIZE * game.size, CELL_SIZE * (i + 1));
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(CELL_SIZE * (i + 1), CELL_SIZE);
+    ctx.lineTo(CELL_SIZE * (i + 1), CELL_SIZE * game.size);
+    ctx.stroke();
+  }
+
+  // draw star points for 9x9
+  const star = [
+    [2, 2],
+    [2, 6],
+    [6, 2],
+    [6, 6],
+    [4, 4],
+  ];
+  for (const [x, y] of star) {
+    ctx.beginPath();
+    ctx.fillStyle = '#000';
+    ctx.arc((x + 1) * CELL_SIZE, (y + 1) * CELL_SIZE, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  drawStones();
+}
+
+function drawStones() {
+  for (let x = 0; x < game.size; x++) {
+    for (let y = 0; y < game.size; y++) {
+      if (game.board[x][y] !== 0) {
+        ctx.beginPath();
+        ctx.fillStyle = game.board[x][y] === 1 ? '#000' : '#fff';
+        ctx.strokeStyle = '#000';
+        ctx.arc(
+          (x + 1) * CELL_SIZE,
+          (y + 1) * CELL_SIZE,
+          CELL_SIZE / 2 - 2,
+          0,
+          Math.PI * 2
+        );
+        ctx.fill();
+        ctx.stroke();
+      }
+    }
+  }
+}
+
+canvas.addEventListener('click', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = Math.round((e.clientX - rect.left) / CELL_SIZE - 1);
+  const y = Math.round((e.clientY - rect.top) / CELL_SIZE - 1);
+  if (game.attemptPlace(x, y)) {
+    drawBoard();
+  }
+});
+
+document.getElementById('undo').addEventListener('click', () => {
+  if (game.undo()) {
+    drawBoard();
+  }
+});
+
+drawBoard();


### PR DESCRIPTION
## Summary
- add GoGame logic for placing stones, capturing, ko and undo
- render a 9x9 board on a canvas and allow user interaction

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841e1ab4784832e82a077e32b4537a4