### PR TITLE
Add board background

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,11 @@ let hoverPos = null;
 
 function drawBoard() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const extra = 5; // padding around the outer stones
+  const boardStart = CELL_SIZE / 2 - extra;
+  const boardSize = CELL_SIZE * game.size + extra * 2;
+  ctx.fillStyle = '#DDB06D';
+  ctx.fillRect(boardStart, boardStart, boardSize, boardSize);
   ctx.strokeStyle = '#000';
   ctx.lineWidth = 1;
   for (let i = 0; i < game.size; i++) {


### PR DESCRIPTION
## Summary
- add rectangular Go board fill behind grid lines

## Testing
- `npm install`
- `npm run build`
- `npm run preview` *(fails: process blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6841e8f3b778832ebfe797604df3a0e0