### PR TITLE
Improve board layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,43 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kifu Compass</title>
+    <style>
+      html,
+      body,
+      #app {
+        height: 100%;
+        margin: 0;
+      }
+
+      #app {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .banner {
+        width: 100%;
+        text-align: center;
+        background: #333;
+        color: #fff;
+        padding: 0.5rem 0;
+      }
+
+      .board-container {
+        flex: 1;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0.5rem 0;
+      }
+
+      #board {
+        max-width: 100%;
+        max-height: 100%;
+        aspect-ratio: 1 / 1;
+      }
+    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,10 @@ import GoGame from './board.js';
 
 const app = document.querySelector('#app');
 app.innerHTML = `
-  <h1>Kifu Compass</h1>
-  <canvas id="board" width="450" height="450"></canvas>
+  <div class="banner"><h1>Kifu Compass</h1></div>
+  <div class="board-container">
+    <canvas id="board"></canvas>
+  </div>
   <div>
     <button id="undo">Back</button>
   </div>
@@ -14,7 +16,14 @@ const canvas = document.getElementById('board');
 const ctx = canvas.getContext('2d');
 const game = new GoGame(9);
 
-const CELL_SIZE = canvas.width / (game.size + 1);
+let CELL_SIZE;
+
+function updateCanvasSize() {
+  const size = canvas.clientWidth;
+  canvas.width = size;
+  canvas.height = size;
+  CELL_SIZE = canvas.width / (game.size + 1);
+}
 let hoverPos = null;
 
 function drawBoard() {
@@ -128,4 +137,10 @@ document.getElementById('undo').addEventListener('click', () => {
   }
 });
 
+updateCanvasSize();
 drawBoard();
+
+window.addEventListener('resize', () => {
+  updateCanvasSize();
+  drawBoard();
+});


### PR DESCRIPTION
## Summary
- style the page with a banner and responsive board container
- render a resizable Go board that stays centered
- handle window resize events so the canvas scales with the container

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68425ee73db4832e9131264cd5d43e60