### PR TITLE
Fix responsive Go board canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,8 @@
       }
 
       #board {
-        max-width: 100%;
+        width: 100%;
+        height: auto;
         max-height: 100%;
         aspect-ratio: 1 / 1;
       }

--- a/src/main.js
+++ b/src/main.js
@@ -19,9 +19,14 @@ const game = new GoGame(9);
 let CELL_SIZE;
 
 function updateCanvasSize() {
-  const size = canvas.clientWidth;
+  const container = canvas.parentElement;
+  const size = Math.min(container.clientWidth, container.clientHeight);
+
+  canvas.style.width = `${size}px`;
+  canvas.style.height = `${size}px`;
   canvas.width = size;
   canvas.height = size;
+
   CELL_SIZE = canvas.width / (game.size + 1);
 }
 let hoverPos = null;


### PR DESCRIPTION
## Summary
- resize board canvas using its parent container so it scales with the layout
- allow the canvas to expand to the parent container via CSS

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684260be149c832e8941a95c0d907f05