### PR TITLE
Add forward and clear buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,12 @@
         max-height: 100%;
         aspect-ratio: 1 / 1;
       }
+
+      .controls {
+        display: flex;
+        gap: 0.5rem;
+        padding-bottom: 0.5rem;
+      }
     </style>
   </head>
   <body>

--- a/src/board.js
+++ b/src/board.js
@@ -4,6 +4,7 @@ class GoGame {
     this.board = Array.from({ length: size }, () => Array(size).fill(0));
     this.currentPlayer = 1; // 1 = black, 2 = white
     this.history = [this.cloneBoard(this.board)];
+    this.currentIndex = 0;
   }
 
   cloneBoard(board) {
@@ -87,23 +88,41 @@ class GoGame {
     }
 
     // Ko check
-    if (this.history.length >= 2) {
-      const prevStr = this.boardToString(this.history[this.history.length - 2]);
+    if (this.currentIndex >= 1) {
+      const prevStr = this.boardToString(this.history[this.currentIndex - 1]);
       if (prevStr === this.boardToString(newBoard)) return false;
     }
 
     this.board = newBoard;
+    // drop future moves if new move is made after undo
+    this.history = this.history.slice(0, this.currentIndex + 1);
     this.history.push(this.cloneBoard(this.board));
-    this.currentPlayer = opp;
+    this.currentIndex++;
+    this.currentPlayer = this.currentIndex % 2 === 0 ? 1 : 2;
     return true;
   }
 
   undo() {
-    if (this.history.length <= 1) return false;
-    this.history.pop();
-    this.board = this.cloneBoard(this.history[this.history.length - 1]);
-    this.currentPlayer = this.currentPlayer === 1 ? 2 : 1;
+    if (this.currentIndex <= 0) return false;
+    this.currentIndex--;
+    this.board = this.cloneBoard(this.history[this.currentIndex]);
+    this.currentPlayer = this.currentIndex % 2 === 0 ? 1 : 2;
     return true;
+  }
+
+  redo() {
+    if (this.currentIndex >= this.history.length - 1) return false;
+    this.currentIndex++;
+    this.board = this.cloneBoard(this.history[this.currentIndex]);
+    this.currentPlayer = this.currentIndex % 2 === 0 ? 1 : 2;
+    return true;
+  }
+
+  clear() {
+    this.board = Array.from({ length: this.size }, () => Array(this.size).fill(0));
+    this.history = [this.cloneBoard(this.board)];
+    this.currentIndex = 0;
+    this.currentPlayer = 1;
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,8 +6,10 @@ app.innerHTML = `
   <div class="board-container">
     <canvas id="board"></canvas>
   </div>
-  <div>
-    <button id="undo">Back</button>
+  <div class="controls">
+    <button id="back" title="Back">⬅️</button>
+    <button id="forward" title="Forward">➡️</button>
+    <button id="clear" title="Clear">🗑️</button>
   </div>
   <div id="suggestion"></div>
 `;
@@ -21,7 +23,7 @@ let CELL_SIZE;
 function updateCanvasSize() {
   const container = canvas.parentElement;
   const header = document.querySelector('.banner');
-  const undo = document.getElementById('undo');
+  const controls = document.querySelector('.controls');
   const suggestion = document.getElementById('suggestion');
 
   const paddingTop = parseFloat(getComputedStyle(container).paddingTop) || 0;
@@ -30,7 +32,7 @@ function updateCanvasSize() {
   const availableHeight =
     window.innerHeight -
     header.offsetHeight -
-    undo.offsetHeight -
+    controls.offsetHeight -
     suggestion.offsetHeight -
     paddingTop -
     paddingBottom;
@@ -151,10 +153,21 @@ canvas.addEventListener('mouseleave', () => {
   drawBoard();
 });
 
-document.getElementById('undo').addEventListener('click', () => {
+document.getElementById('back').addEventListener('click', () => {
   if (game.undo()) {
     drawBoard();
   }
+});
+
+document.getElementById('forward').addEventListener('click', () => {
+  if (game.redo()) {
+    drawBoard();
+  }
+});
+
+document.getElementById('clear').addEventListener('click', () => {
+  game.clear();
+  drawBoard();
 });
 
 updateCanvasSize();


### PR DESCRIPTION
## Summary
- add redo and clear logic to `GoGame`
- show new Back/Forward/Clear buttons with icons
- resize board with controls container
- wire up new buttons to undo/redo/clear
- style controls in `index.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843307ec4b4832eb21eb7bd52a5b882