### PR TITLE
Add next move suggestion API mock

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,7 @@
 import GoGame from './board.js';
+import { worker } from './mocks/browser.js';
+
+worker.start();
 
 import black00 from './assets/stones/black00_128.png';
 import black01 from './assets/stones/black01_128.png';
@@ -213,6 +216,18 @@ canvas.addEventListener('click', (e) => {
     boardImagesHistory.push(boardImages.map((row) => row.slice()));
     hoverImg = null;
     drawBoard();
+
+    const boardStr = game.boardToString(game.board);
+    fetch('/api/next-moves', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ board: boardStr }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        console.log('next moves', data);
+      })
+      .catch((err) => console.error(err));
   }
 });
 

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -1,4 +1,4 @@
-import { setupWorker } from "msw";
-import { handlers } from "./handlers";
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handler";
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/handler.js
+++ b/src/mocks/handler.js
@@ -1,7 +1,20 @@
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 
 export const handlers = [
-  rest.get("/api/next-moves", (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ moves: [] }));
+  http.post("/api/next-moves", async ({ request }) => {
+    const { board } = await request.json();
+    const size = Math.sqrt(board.length);
+    const moves = [];
+    for (let i = 0; i < size; i++) {
+      for (let j = 0; j < size; j++) {
+        if (board[i * size + j] === "0") {
+          moves.push({
+            move: [i, j],
+            count: Math.floor(Math.random() * 100),
+          });
+        }
+      }
+    }
+    return HttpResponse.json({ moves });
   }),
 ];


### PR DESCRIPTION
## Summary
- start the MSW worker from `main.js`
- mock `/api/next-moves` using MSW `http` handlers
- send board state to `/api/next-moves` after each move

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684870016214832e9efdbb7d8963adc8