### PR TITLE
Update mock next-moves API

### DIFF
--- a/src/mocks/handler.js
+++ b/src/mocks/handler.js
@@ -15,6 +15,11 @@ export const handlers = [
         }
       }
     }
-    return HttpResponse.json({ moves });
+
+    const maxMoves = Math.max(1, Math.floor(moves.length / 2));
+    const numMoves = Math.floor(Math.random() * maxMoves) + 1;
+    const subset = moves.sort(() => 0.5 - Math.random()).slice(0, numMoves);
+
+    return HttpResponse.json({ moves: subset });
   }),
 ];


### PR DESCRIPTION
## Summary
- modify the mock `/api/next-moves` handler
- return a random subset of available moves instead of all of them

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848775010f0832eaebc1c62752bf710