### PR TITLE
Add initial suggestions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,23 @@ let hoverColor = null;
 
 let suggestedMoves = [];
 
+function fetchSuggestedMoves() {
+  const boardStr = game.boardToString(game.board);
+  fetch('/api/next-moves', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ board: boardStr }),
+  })
+    .then((res) => res.json())
+    .then((data) => {
+      if (data && Array.isArray(data.moves)) {
+        suggestedMoves = data.moves;
+        drawBoard();
+      }
+    })
+    .catch((err) => console.error(err));
+}
+
 let CELL_SIZE;
 
 function updateCanvasSize() {
@@ -248,20 +265,7 @@ canvas.addEventListener('click', (e) => {
     suggestedMoves = [];
     drawBoard();
 
-    const boardStr = game.boardToString(game.board);
-    fetch('/api/next-moves', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ board: boardStr }),
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        if (data && Array.isArray(data.moves)) {
-          suggestedMoves = data.moves;
-          drawBoard();
-        }
-      })
-      .catch((err) => console.error(err));
+    fetchSuggestedMoves();
   }
 });
 
@@ -302,6 +306,9 @@ document.getElementById('back').addEventListener('click', () => {
     boardImages = boardImagesHistory[game.currentIndex].map((row) => row.slice());
     suggestedMoves = [];
     drawBoard();
+    if (game.currentIndex === 0) {
+      fetchSuggestedMoves();
+    }
   }
 });
 
@@ -320,10 +327,12 @@ document.getElementById('clear').addEventListener('click', () => {
   hoverImg = null;
   suggestedMoves = [];
   drawBoard();
+  fetchSuggestedMoves();
 });
 
 updateCanvasSize();
 drawBoard();
+fetchSuggestedMoves();
 
 window.addEventListener('resize', () => {
   updateCanvasSize();


### PR DESCRIPTION
## Summary
- show next-moves circles even when the board is empty
- call next-moves API on page load
- refresh suggestions on clearing or undoing to the start

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505e6aa044832e835307128c229f3c