### PR TITLE
Refactor main.js into modules

### DIFF
--- a/src/utils/boardRenderer.js
+++ b/src/utils/boardRenderer.js
@@ -1,0 +1,155 @@
+let CELL_SIZE = 0;
+
+export function getCellSize() {
+  return CELL_SIZE;
+}
+
+export function updateCanvasSize(canvas, boardCanvas, game) {
+  const container = canvas.parentElement;
+  const header = document.querySelector(".banner");
+  const controls = document.querySelector(".controls");
+  const suggestion = document.getElementById("suggestion");
+
+  const paddingTop = parseFloat(getComputedStyle(container).paddingTop) || 0;
+  const paddingBottom = parseFloat(getComputedStyle(container).paddingBottom) || 0;
+
+  const availableHeight =
+    window.innerHeight -
+    header.offsetHeight -
+    controls.offsetHeight -
+    suggestion.offsetHeight -
+    paddingTop -
+    paddingBottom;
+
+  const size = Math.min(container.clientWidth, availableHeight);
+
+  canvas.style.width = `${size}px`;
+  canvas.style.height = `${size}px`;
+  canvas.width = size;
+  canvas.height = size;
+  boardCanvas.width = size;
+  boardCanvas.height = size;
+
+  CELL_SIZE = canvas.width / (game.size + 1);
+}
+
+export function drawBoardBackground(boardCtx, game) {
+  boardCtx.clearRect(0, 0, boardCtx.canvas.width, boardCtx.canvas.height);
+  const extra = 5; // padding around the outer stones
+  const boardStart = CELL_SIZE / 2 - extra;
+  const boardSize = CELL_SIZE * game.size + extra * 2;
+  boardCtx.fillStyle = "#DDB06D";
+  boardCtx.fillRect(boardStart, boardStart, boardSize, boardSize);
+  boardCtx.strokeStyle = "#000";
+  boardCtx.lineWidth = 1;
+  for (let i = 0; i < game.size; i++) {
+    boardCtx.beginPath();
+    boardCtx.moveTo(CELL_SIZE, CELL_SIZE * (i + 1));
+    boardCtx.lineTo(CELL_SIZE * game.size, CELL_SIZE * (i + 1));
+    boardCtx.stroke();
+
+    boardCtx.beginPath();
+    boardCtx.moveTo(CELL_SIZE * (i + 1), CELL_SIZE);
+    boardCtx.lineTo(CELL_SIZE * (i + 1), CELL_SIZE * game.size);
+    boardCtx.stroke();
+  }
+
+  // draw star points for 9x9
+  const star = [
+    [2, 2],
+    [2, 6],
+    [6, 2],
+    [6, 6],
+    [4, 4],
+  ];
+  for (const [x, y] of star) {
+    boardCtx.beginPath();
+    boardCtx.fillStyle = "#000";
+    boardCtx.arc((x + 1) * CELL_SIZE, (y + 1) * CELL_SIZE, 3, 0, Math.PI * 2);
+    boardCtx.fill();
+  }
+}
+
+export function drawStones(ctx, boardImages, game) {
+  const size = CELL_SIZE - 4;
+  for (let x = 0; x < game.size; x++) {
+    for (let y = 0; y < game.size; y++) {
+      if (game.board[x][y] !== 0) {
+        const img = boardImages[x][y];
+        if (img) {
+          ctx.drawImage(
+            img,
+            (x + 1) * CELL_SIZE - size / 2,
+            (y + 1) * CELL_SIZE - size / 2,
+            size,
+            size
+          );
+        } else {
+          ctx.beginPath();
+          ctx.fillStyle = game.board[x][y] === 1 ? "#000" : "#fff";
+          ctx.arc(
+            (x + 1) * CELL_SIZE,
+            (y + 1) * CELL_SIZE,
+            CELL_SIZE / 2 - 2,
+            0,
+            Math.PI * 2
+          );
+          ctx.fill();
+        }
+      }
+    }
+  }
+}
+
+export function drawSuggestedMoves(ctx, suggestedMoves, game) {
+  if (!suggestedMoves.length) return;
+  const radius = CELL_SIZE / 2 - 2;
+  const max = Math.max(...suggestedMoves.map((m) => m.count));
+  const startColor = { r: 173, g: 216, b: 230 };
+  const endColor = { r: 0, g: 0, b: 139 };
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.font = `${CELL_SIZE / 2}px Arial`;
+  for (const { move, count } of suggestedMoves) {
+    const [x, y] = move;
+    if (game.board[x][y] !== 0) continue;
+    const ratio = max === 0 ? 0 : count / max;
+    const r = Math.round(startColor.r + ratio * (endColor.r - startColor.r));
+    const g = Math.round(startColor.g + ratio * (endColor.g - startColor.g));
+    const b = Math.round(startColor.b + ratio * (endColor.b - startColor.b));
+    ctx.fillStyle = `rgb(${r},${g},${b})`;
+    ctx.globalAlpha = 0.6;
+    ctx.beginPath();
+    ctx.arc((x + 1) * CELL_SIZE, (y + 1) * CELL_SIZE, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = ratio > 0.5 ? "#fff" : "#000";
+    ctx.fillText(count, (x + 1) * CELL_SIZE, (y + 1) * CELL_SIZE);
+  }
+}
+
+export function drawHoverStone(ctx, hoverPos, hoverImg, game) {
+  if (!hoverPos) return;
+  const { x, y } = hoverPos;
+  if (x < 0 || x >= game.size || y < 0 || y >= game.size) return;
+  if (game.board[x][y] !== 0) return;
+  const size = CELL_SIZE - 4;
+  if (!hoverImg) return;
+  ctx.globalAlpha = 0.6;
+  ctx.drawImage(
+    hoverImg,
+    (x + 1) * CELL_SIZE - size / 2,
+    (y + 1) * CELL_SIZE - size / 2,
+    size,
+    size
+  );
+  ctx.globalAlpha = 1;
+}
+
+export function drawBoard(ctx, boardCanvas, boardImages, suggestedMoves, hoverPos, hoverImg, game) {
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  ctx.drawImage(boardCanvas, 0, 0);
+  drawStones(ctx, boardImages, game);
+  drawSuggestedMoves(ctx, suggestedMoves, game);
+  drawHoverStone(ctx, hoverPos, hoverImg, game);
+}

--- a/src/utils/imageLoader.js
+++ b/src/utils/imageLoader.js
@@ -1,0 +1,41 @@
+import black00 from "../assets/stones/black00_128.png";
+import black01 from "../assets/stones/black01_128.png";
+import black02 from "../assets/stones/black02_128.png";
+import black03 from "../assets/stones/black03_128.png";
+import white00 from "../assets/stones/white00_128.png";
+import white01 from "../assets/stones/white01_128.png";
+import white02 from "../assets/stones/white02_128.png";
+import white03 from "../assets/stones/white03_128.png";
+import white04 from "../assets/stones/white04_128.png";
+import white05 from "../assets/stones/white05_128.png";
+import white06 from "../assets/stones/white06_128.png";
+import white07 from "../assets/stones/white07_128.png";
+import white08 from "../assets/stones/white08_128.png";
+import white09 from "../assets/stones/white09_128.png";
+import white10 from "../assets/stones/white10_128.png";
+
+const blackSources = [black00, black01, black02, black03];
+const whiteSources = [
+  white00,
+  white01,
+  white02,
+  white03,
+  white04,
+  white05,
+  white06,
+  white07,
+  white08,
+  white09,
+  white10,
+];
+
+export function createImages(srcArr) {
+  return srcArr.map((src) => {
+    const img = new Image();
+    img.src = src;
+    return img;
+  });
+}
+
+export const blackImages = createImages(blackSources);
+export const whiteImages = createImages(whiteSources);

--- a/src/utils/suggestions.js
+++ b/src/utils/suggestions.js
@@ -1,0 +1,16 @@
+export function fetchSuggestedMoves(game, setMoves, drawBoard) {
+  const boardStr = game.boardToString(game.board);
+  return fetch("/api/next-moves", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ board: boardStr }),
+  })
+    .then((res) => res.json())
+    .then((data) => {
+      if (data && Array.isArray(data.moves)) {
+        setMoves(data.moves);
+        drawBoard();
+      }
+    })
+    .catch((err) => console.error(err));
+}


### PR DESCRIPTION
## Summary
- break up `main.js` logic
- add new util modules for image loading, board rendering and suggestions
- update main script to use those modules

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685306f9843c832ebaab7aa04bb66a6a